### PR TITLE
Convenience for testing

### DIFF
--- a/src/react-disposable-decorator.js
+++ b/src/react-disposable-decorator.js
@@ -9,7 +9,7 @@ if (!enabled) {
 
 export default function(DecoratedComponent) {
 	if (!enabled) {
-		return DecoratedComponent;
+		return <DecoratedComponent cancelWhenUnmounted={() => {}} />;
 	}
 
 	return class Disposable extends React.Component {


### PR DESCRIPTION
When disabled for tests, every component rendered by shallow must define
cancelWhenUnmounted. This change makes it so that is no longer necessary.