### PR TITLE
always define cancelWhenUnmounted

### DIFF
--- a/src/react-disposable-decorator.js
+++ b/src/react-disposable-decorator.js
@@ -5,7 +5,9 @@ const inTestingEnv = typeof jasmine !== 'undefined';
 
 export default function(DecoratedComponent) {
   if (disabled) {
-    return DecoratedComponent;
+    return <DecoratedComponent
+      cancelWhenUnmounted={()=>{}}
+    />
   }
 
   const originalDisplayName = DecoratedComponent.displayName || DecoratedComponent.name;


### PR DESCRIPTION
if global.disableReactDisposableDecorator = true formerly written tests will now break because `cancelWhenUnmounted` is undefined. For future development, why require devs to always include this prop in testing decorated components?